### PR TITLE
Improve support for fireworks-ai/llama-3-firefunction-v2

### DIFF
--- a/include/minja/minja.hpp
+++ b/include/minja/minja.hpp
@@ -2401,6 +2401,14 @@ inline std::shared_ptr<Context> Context::builtins() {
     auto & text = args.at("text");
     return text.is_null() ? text : Value(strip(text.get<std::string>()));
   }));
+  globals.set("lower", simple_function("lower", { "text" }, [](const std::shared_ptr<Context> &, Value & args) {
+    auto text = args.at("text");
+    if (text.is_null()) return text;
+    std::string res;
+    auto str = text.get<std::string>();
+    std::transform(str.begin(), str.end(), std::back_inserter(res), ::tolower);
+    return Value(res);
+  }));
   globals.set("default", Value::callable([=](const std::shared_ptr<Context> &, Value::Arguments & args) {
     args.expectArgs("default", {2, 3}, {0, 1});
     auto & value = args.args[0];

--- a/include/minja/minja.hpp
+++ b/include/minja/minja.hpp
@@ -2401,6 +2401,21 @@ inline std::shared_ptr<Context> Context::builtins() {
     auto & text = args.at("text");
     return text.is_null() ? text : Value(strip(text.get<std::string>()));
   }));
+  globals.set("default", Value::callable([=](const std::shared_ptr<Context> &, Value::Arguments & args) {
+    args.expectArgs("default", {2, 3}, {0, 1});
+    auto & value = args.args[0];
+    auto & default_value = args.args[1];
+    bool boolean = false;
+    if (args.args.size() == 3) {
+      boolean = args.args[2].get<bool>();
+    } else {
+      Value bv = args.get_named("boolean");
+      if (!bv.is_null()) {
+        boolean = bv.get<bool>();
+      }
+    }
+    return boolean ? (value.to_bool() ? value : default_value) : value.is_null() ? default_value : value;
+  }));
   auto escape = simple_function("escape", { "text" }, [](const std::shared_ptr<Context> &, Value & args) {
     return Value(html_escape(args.at("text").get<std::string>()));
   });

--- a/include/minja/minja.hpp
+++ b/include/minja/minja.hpp
@@ -433,12 +433,18 @@ public:
     return dump();
   }
   Value operator+(const Value& rhs) const {
-      if (is_string() || rhs.is_string())
+      if (is_string() || rhs.is_string()) {
         return to_str() + rhs.to_str();
-      else if (is_number_integer() && rhs.is_number_integer())
+      } else if (is_number_integer() && rhs.is_number_integer()) {
         return get<int64_t>() + rhs.get<int64_t>();
-      else
+      } else if (is_array() && rhs.is_array()) {
+        auto res = Value::array();
+        for (const auto& item : *array_) res.push_back(item);
+        for (const auto& item : *rhs.array_) res.push_back(item);
+        return res;
+      } else {
         return get<double>() + rhs.get<double>();
+      }
   }
   Value operator-(const Value& rhs) const {
       if (is_number_integer() && rhs.is_number_integer())

--- a/tests/test-syntax.cpp
+++ b/tests/test-syntax.cpp
@@ -49,7 +49,9 @@ TEST(SyntaxTest, SimpleCases) {
     EXPECT_EQ(
         "abc",
         render("{% filter trim %} abc {% endfilter %}", {}, {}));
-
+    EXPECT_EQ(
+        "[1, 2, 3]",
+        render("{{ [1] + [2, 3] }}", {}, {}));
     EXPECT_EQ(
         "a\n  b\n|  a\n  b\n",
         render("{% set txt = 'a\\nb\\n' %}{{ txt | indent(2) }}|{{ txt | indent(2, first=true) }}", {}, {}));

--- a/tests/test-syntax.cpp
+++ b/tests/test-syntax.cpp
@@ -53,6 +53,9 @@ TEST(SyntaxTest, SimpleCases) {
         "[1, 2, 3]",
         render("{{ [1] + [2, 3] }}", {}, {}));
     EXPECT_EQ(
+        "abc",
+        render("{{ 'AbC' | lower }}", {}, {}));
+    EXPECT_EQ(
         "the default1",
         render("{{ foo | default('the default') }}{{ 1 | default('nope') }}", {}, {}));
     EXPECT_EQ(

--- a/tests/test-syntax.cpp
+++ b/tests/test-syntax.cpp
@@ -53,6 +53,12 @@ TEST(SyntaxTest, SimpleCases) {
         "[1, 2, 3]",
         render("{{ [1] + [2, 3] }}", {}, {}));
     EXPECT_EQ(
+        "the default1",
+        render("{{ foo | default('the default') }}{{ 1 | default('nope') }}", {}, {}));
+    EXPECT_EQ(
+        "the default1",
+        render("{{ '' | default('the default', true) }}{{ 1 | default('nope', true) }}", {}, {}));
+    EXPECT_EQ(
         "a\n  b\n|  a\n  b\n",
         render("{% set txt = 'a\\nb\\n' %}{{ txt | indent(2) }}|{{ txt | indent(2, first=true) }}", {}, {}));
     EXPECT_EQ(


### PR DESCRIPTION
*Almost* fixes https://github.com/google/minja/issues/7

This adds the following features:
- [x] array concat w/ `+`
- [x] lower filter
- [x] default filter

Still some issues w/ `functions` and `datetime` expected in template (crashes jinja2), which get resolved to None if I add them in the context. Will do a follow up PR.