### PR TITLE
Add reasoning/thinking capability detection and polyfills

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ It is **not general purpose**: it includes just what’s needed for actual chat 
 
 This library is header-only: just copy the header(s) you need, make sure to use a compiler that handles C++11 and you're done. Oh, and get [nlohmann::json](https://github.com/nlohmann/json)'s `json.hpp` in your include path.
 
-See API in [minja/minja.hpp](./include/minja/chat-template.hpp) and [minja/chat-template.h](./include/minja/chat-template.hpp) (experimental).
+See API in [minja/minja.hpp](./include/minja/minja.hpp) and [minja/chat-template.h](./include/minja/chat-template.hpp) (experimental).
 
 For raw Jinja templating (see [examples/raw.cpp](./examples/raw.cpp)):
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive support for detecting and polyfilling reasoning/thinking capabilities in chat templates. Different LLMs use various patterns to represent chain-of-thought reasoning, and this PR enables automatic detection and conversion between formats.

## Features

### Reasoning Format Detection

Added `ReasoningFormat` enum to identify how templates handle reasoning:

| Format | Field/Structure | Models |
|--------|----------------|--------|
| `REASONING_CONTENT` | `message.reasoning_content` | Qwen3, GLM-4.6/4.7 |
| `THOUGHT_FIELD` | `message.thought` | MiniCPM3 |
| `THINKING_FIELD` | `message.thinking` | GPT-OSS-120B |
| `TOOL_PLAN_FIELD` | `message.tool_plan` (requires tool_calls) | Command-R7B |
| `CONTENT_BLOCK_THINKING` | `content[].type == "thinking"` | Ministral |
| `CONTENT_BLOCK_THOUGHTS` | `content[].type == "thoughts"` | Apertus |

### New Capability Flags

```cpp
struct chat_template_caps {
    // ... existing fields ...
    
    // Reasoning capabilities
    bool supports_reasoning = false;           // Template supports some reasoning format
    ReasoningFormat reasoning_format = NONE;   // Which format the template uses
    bool reasoning_requires_tools = false;     // Reasoning only works with tool_calls (Command-R7B)
    
    // Behavior flags (computed via detection probes)
    bool supports_reasoning_without_content = false;  // Can emit reasoning with empty content
    bool supports_reasoning_with_content = false;     // Can emit both reasoning and content
    bool respects_enable_reasoning = false;           // Honors enable_thinking=false
    bool supports_clear_thinking = false;             // Honors clear_thinking flag (default: true)
};
```

### Canonical Input Interface

```typescript
interface Message {
  role: "system" | "user" | "assistant" | "tool";
  content: string | null;
  reasoning_content?: string;  // Canonical reasoning input
  tool_calls?: ToolCall[];
  tool_call_id?: string;       // For tool responses
  name?: string;               // Tool name
}

interface ChatTemplateInputs {
  messages: Message[];
  tools?: Tool[];
  add_generation_prompt?: boolean;  // default: true
  enable_thinking?: boolean;        // default: true
  clear_thinking?: boolean;         // default: true (only show last reasoning)
}
```

### Automatic Polyfilling

Messages with `reasoning_content` are automatically polyfilled to the template's native format:

```cpp
// Input message (canonical format)
{"role": "assistant", "reasoning_content": "Let me think...", "content": "The answer is 42."}

// Polyfilled for MiniCPM3 (THOUGHT_FIELD)
{"role": "assistant", "thought": "Let me think...", "content": "The answer is 42."}

// Polyfilled for Ministral (CONTENT_BLOCK_THINKING)
{"role": "assistant", "content": [
    {"type": "thinking", "thinking": "Let me think..."},
    {"type": "text", "text": "The answer is 42."}
]}
```

### Test Infrastructure

Added `_test_metadata` to context JSON files for template-independent validation:

```json
{
  "_test_metadata": {
    "expected_strings": ["always present"],
    "expected_strings_if_supports_reasoning": ["reasoning text"],
    "expected_strings_if_supports_tool_calls": ["tool name"],
    "forbidden_strings": ["should never appear"]
  }
}
```

## Test Contexts

| Context | Description |
|---------|-------------|
| `reasoning_only.json` | Basic reasoning with content |
| `reasoning_multi_turn.json` | Multi-turn reasoning conversation |
| `reasoning_position_based.json` | Tests position-based visibility |
| `reasoning_clear_thinking.json` | Tests `clear_thinking=false` flag |
| `reasoning_with_tools.json` | Reasoning combined with tool calls |
| `reasoning_disabled.json` | Tests `enable_thinking=false` |
| `tool_plan_reasoning.json` | Multi-step tool calls with reasoning |

## Implementation

- **C++**: `include/minja/chat-template.hpp`
- **Python**: `scripts/fetch_templates_and_goldens.py`
- **Tests**: `tests/test-capabilities.cpp`, `tests/test-supported-template.cpp`

All 870 tests pass.

Closes #19