### PR TITLE
Fix bofenghuang/vigogne-2-70b-chat on Windows

### DIFF
--- a/include/minja/minja.hpp
+++ b/include/minja/minja.hpp
@@ -1305,12 +1305,10 @@ struct ArgumentsExpression {
 };
 
 static std::string strip(const std::string & s) {
-  static std::regex trailing_spaces_regex("^\\s+|\\s+$");
-  return std::regex_replace(s, trailing_spaces_regex, "");
-  // auto start = s.find_first_not_of(" \t\n\r");
-  // if (start == std::string::npos) return "";
-  // auto end = s.find_last_not_of(" \t\n\r");
-  // return s.substr(start, end - start + 1);
+  auto start = s.find_first_not_of(" \t\n\r");
+  if (start == std::string::npos) return "";
+  auto end = s.find_last_not_of(" \t\n\r");
+  return s.substr(start, end - start + 1);
 }
 
 static std::string html_escape(const std::string & s) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -83,12 +83,6 @@ set(MODEL_IDS
     # xai-org/grok-1
 )
 
-if(WIN32)
-    list(REMOVE_ITEM MODEL_IDS
-        bofenghuang/vigogne-2-70b-chat
-    )
-endif()
-
 # Create one test case for each {template, context} combination
 file(GLOB CONTEXT_FILES "${CMAKE_SOURCE_DIR}/tests/contexts/*.json")
 execute_process(


### PR DESCRIPTION
Now that this model is run on CI (https://github.com/google/minja/pull/21), time to unskip it & promote previously commented-out fix.

Thanks @slaren! ([ref](https://github.com/ggerganov/llama.cpp/pull/11016#issuecomment-2599766199))