### PR TITLE
Move normalize_newlines from test to parser

### DIFF
--- a/include/minja/minja.hpp
+++ b/include/minja/minja.hpp
@@ -2419,7 +2419,7 @@ private:
 public:
 
     static std::shared_ptr<TemplateNode> parse(const std::string& template_str, const Options & options) {
-        Parser parser(std::make_shared<std::string>(template_str), options);
+        Parser parser(std::make_shared<std::string>(normalize_newlines(template_str)), options);
         auto tokens = parser.tokenize();
         TemplateTokenIterator begin = tokens.begin();
         auto it = begin;

--- a/tests/test-chat-template.cpp
+++ b/tests/test-chat-template.cpp
@@ -41,7 +41,7 @@ static std::string read_file(const std::string &path) {
     std::string out;
     out.resize(static_cast<size_t>(size));
     fs.read(&out[0], static_cast<std::streamsize>(size));
-    return minja::normalize_newlines(out);
+    return out;
 }
 
 int main(int argc, char *argv[]) {
@@ -82,7 +82,7 @@ int main(int argc, char *argv[]) {
 
         std::string expected;
         try {
-            expected = read_file(golden_file);
+            expected = minja::normalize_newlines(read_file(golden_file));
         } catch (const std::exception &e) {
             std::cerr << "Failed to read golden file: " << golden_file << std::endl;
             std::cerr << e.what() << std::endl;


### PR DESCRIPTION
Quick follow up to https://github.com/google/minja/pull/26
Parser needs to protect against \r\n by itself, can't just rely on caller (here, test) to pass \n delimited lines only