### PR TITLE
accept a const value ref in Context::set

### DIFF
--- a/include/minja/minja.hpp
+++ b/include/minja/minja.hpp
@@ -628,7 +628,7 @@ class Context : public std::enable_shared_from_this<Context> {
         if (parent_) return parent_->contains(key);
         return false;
     }
-    virtual void set(const Value & key, Value & value) {
+    virtual void set(const Value & key, const Value & value) {
         values_.set(key, value);
     }
 };


### PR DESCRIPTION
Everything seems to compile fine when this is const. It being non-const makes it hard to pass in a temporary (rvalue).

**edit:** ~~I intend to sign the CLA but it's going to take me some time to figure out the Google Groups stuff that I need.~~