### PR TITLE
Fix hang when parsing unclosed comment

### DIFF
--- a/include/minja/minja.hpp
+++ b/include/minja/minja.hpp
@@ -2160,7 +2160,7 @@ private:
       static std::regex expr_open_regex(R"(\{\{([-~])?)");
       static std::regex block_open_regex(R"(^\{%([-~])?[\s\n\r]*)");
       static std::regex block_keyword_tok(R"((if|else|elif|endif|for|endfor|generation|endgeneration|set|endset|block|endblock|macro|endmacro|filter|endfilter)\b)");
-      static std::regex text_regex(R"([\s\S\r\n]*?($|(?=\{\{|\{%|\{#)))", std::regex::multiline);
+      static std::regex text_regex(R"([\s\S\r\n]*?(?=\{[{%#]|$))");
       static std::regex expr_close_regex(R"([\s\n\r]*([-~])?\}\})");
       static std::regex block_close_regex(R"([\s\n\r]*([-~])?%\})");
 


### PR DESCRIPTION
Since c73b53f, minja hangs when parsing the template `{#`, e.g.:

```cpp
#include <minja/minja.hpp>
int main() {
    try {
        minja::Parser::parse("{#", {});
    } catch (...) {
        return 1;
    }
}
```

This program should exit with status code 1, but instead it hangs.

I tried a different fix for the lack of `std::regex::multiline` on MSVC, and it no longer hangs. Also, all of the tests pass&mdash;it seems like the version with `multiline` was also buggy. `multiline` makes anchors *match* at the end of a line, which I think is the opposite of what was intended.

The ability to parse incomplete templates without crashing or hanging is important to GPT4All, which parses the template as it is being typed in the Settings page. This provides instant feedback on whether it is valid.

I'd like to add a regression test for this change. Let me know where it belongs. Or, you can add one if you'd like.