### PR TITLE
Fix multiline comments (. isn't multiline, need [\s\S\r\n])

### DIFF
--- a/include/minja/minja.hpp
+++ b/include/minja/minja.hpp
@@ -2194,7 +2194,7 @@ private:
     }
 
     TemplateTokenVector tokenize() {
-      static std::regex comment_tok(R"(\{#([-~]?)(.*?)([-~]?)#\})");
+      static std::regex comment_tok(R"(\{#([-~]?)([\s\S\r\n]*?)([-~]?)#\})");
       static std::regex expr_open_regex(R"(\{\{([-~])?)");
       static std::regex block_open_regex(R"(^\{%([-~])?[\s\n\r]*)");
       static std::regex block_keyword_tok(R"((if|else|elif|endif|for|endfor|generation|endgeneration|set|endset|block|endblock|macro|endmacro|filter|endfilter|break|continue)\b)");

--- a/tests/test-syntax.cpp
+++ b/tests/test-syntax.cpp
@@ -75,6 +75,10 @@ TEST(SyntaxTest, SimpleCases) {
     };
 
     EXPECT_EQ(
+        "ok",
+        render("{# Hey\nHo #}{#- Multiline...\nComments! -#}{{ 'ok' }}{# yo #}", {}, {}));
+    
+    EXPECT_EQ(
         "    b",
         render(R"(  {% set _ = 1 %}    {% set _ = 2 %}b)", {}, lstrip_trim_blocks));
     EXPECT_EQ(


### PR DESCRIPTION
@ericcurtin sorry, finally got to look into it. Hopefully this does the trick, should be a simpler fix than https://github.com/google/minja/pull/37