### PR TITLE
Use the canonical #include location for json.hpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,6 @@ message(STATUS "${fuzztest_BINARY_DIR}: ${${fuzztest_BINARY_DIR}}")
 include_directories(
     include/minja
     ${json_SOURCE_DIR}/include
-    ${json_SOURCE_DIR}/include/nlohmann
 )
 
 add_subdirectory(examples)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ It is **not general purpose**: it includes just what’s needed for actual chat 
 
 ## Usage:
 
-This library is header-only: just copy the header(s) you need, make sure to use a compiler that handles C++17 and you're done. Oh, and get [nlohmann::json](https://github.com/nlohmann/json)'s `json.hpp` in your include path.
+This library is header-only: just copy the header(s) you need, make sure to use a compiler that handles C++17 and you're done. Oh, and get [nlohmann::json](https://github.com/nlohmann/json) in your include path.
 
 See API in [minja/minja.hpp](./include/minja/minja.hpp) and [minja/chat-template.hpp](./include/minja/chat-template.hpp) (experimental).
 

--- a/include/minja/chat-template.hpp
+++ b/include/minja/chat-template.hpp
@@ -9,9 +9,11 @@
 #pragma once
 
 #include "minja.hpp"
-#include <json.hpp>
+
 #include <string>
 #include <vector>
+
+#include <nlohmann/json.hpp>
 
 using json = nlohmann::ordered_json;
 

--- a/include/minja/minja.hpp
+++ b/include/minja/minja.hpp
@@ -16,7 +16,8 @@
 #include <stdexcept>
 #include <sstream>
 #include <unordered_set>
-#include <json.hpp>
+
+#include <nlohmann/json.hpp>
 
 using json = nlohmann::ordered_json;
 


### PR DESCRIPTION
The two simplest ways to get nlohmann/json are to install it system-wide, or to vendor it via CMake.

### System
If you install it system-wide, it will be at `/usr/include/nlohmann/json.hpp` (on Arch Linux, at least). minja is not compatible with this out-of-the-box, requiring you to add the non-standard #include path of `-I/usr/include/nlohmann`.

This is confirmed by `/usr/share/pkgconfig/nlohmann_json.pc`, which does not list `/usr/include/nlohmann` as a required include directory:
```
Name: nlohmann_json
Description: JSON for Modern C++
Version: 3.11.3
Cflags: -I/usr/include
```

### CMake
If you provide the json dependency as part of a CMake project like this:
```cmake
add_subdirectory(deps/json)  # or FetchContent_Declare/FetchContent_MakeAvailable
target_link_libraries(mytarget PRIVATE nlohmann_json::nlohmann_json)
```

The same problem occurs, requring a manual `target_include_directories(mytarget PRIVATE /path/to/nlohmann)`. See [here](https://github.com/nlohmann/json/blob/0b6881a95f8aaf60bd2324ecdf2258a65bf33baf/CMakeLists.txt#L135-L140).

***

This PR fixes those issues by using the canonical header location. This is consistent with the nlohmann json [documentation](https://github.com/nlohmann/json#read-json-from-a-file).