### PR TITLE
Add `upper` filter (to support inclusionAI/Ling-Coder-lite)

### DIFF
--- a/include/minja/minja.hpp
+++ b/include/minja/minja.hpp
@@ -2607,14 +2607,18 @@ inline std::shared_ptr<Context> Context::builtins() {
     auto & text = args.at("text");
     return text.is_null() ? text : Value(strip(text.get<std::string>()));
   }));
-  globals.set("lower", simple_function("lower", { "text" }, [](const std::shared_ptr<Context> &, Value & args) {
-    auto text = args.at("text");
-    if (text.is_null()) return text;
-    std::string res;
-    auto str = text.get<std::string>();
-    std::transform(str.begin(), str.end(), std::back_inserter(res), ::tolower);
-    return Value(res);
-  }));
+  auto char_transform_function = [](const std::string & name, const std::function<char(char)> & fn) {
+    return simple_function(name, { "text" }, [=](const std::shared_ptr<Context> &, Value & args) {
+      auto text = args.at("text");
+      if (text.is_null()) return text;
+      std::string res;
+      auto str = text.get<std::string>();
+      std::transform(str.begin(), str.end(), std::back_inserter(res), fn);
+      return Value(res);
+    });
+  };
+  globals.set("lower", char_transform_function("lower", ::tolower));
+  globals.set("upper", char_transform_function("upper", ::toupper));
   globals.set("default", Value::callable([=](const std::shared_ptr<Context> &, ArgumentsValue & args) {
     args.expectArgs("default", {2, 3}, {0, 1});
     auto & value = args.args[0];

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -137,6 +137,7 @@ set(MODEL_IDS
     huihui-ai/Qwen2.5-14B-Instruct-1M-abliterated
     ibm-granite/granite-3.1-8b-instruct
     Ihor/Text2Graph-R1-Qwen2.5-0.5b
+    inclusionAI/Ling-Coder-lite
     indischepartij/MiniCPM-3B-OpenHermes-2.5-v2
     Infinigence/Megrez-3B-Instruct
     inflatebot/MN-12B-Mag-Mell-R1

--- a/tests/test-syntax.cpp
+++ b/tests/test-syntax.cpp
@@ -88,7 +88,7 @@ TEST(SyntaxTest, SimpleCases) {
     EXPECT_EQ(
         "ok",
         render("{# Hey\nHo #}{#- Multiline...\nComments! -#}{{ 'ok' }}{# yo #}", {}, {}));
-    
+
     EXPECT_EQ(
         "    b",
         render(R"(  {% set _ = 1 %}    {% set _ = 2 %}b)", {}, lstrip_trim_blocks));
@@ -130,6 +130,9 @@ TEST(SyntaxTest, SimpleCases) {
     EXPECT_EQ(
         "abc",
         render("{{ 'AbC' | lower }}", {}, {}));
+    EXPECT_EQ(
+        "ME",
+        render("{{ 'me' | upper }}", {}, {}));
     EXPECT_EQ(
         "the default1",
         render("{{ foo | default('the default') }}{{ 1 | default('nope') }}", {}, {}));


### PR DESCRIPTION
cc/ @CISC ([ref](https://github.com/ggml-org/llama.cpp/pull/12634#issuecomment-2763257852))