### PR TITLE
make minja packagable by setting target in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ if(MINJA_TEST_ENABLED)
         message(STATUS "${fuzztest_BINARY_DIR}: ${${fuzztest_BINARY_DIR}}")
     else()
         # Fetch gtest
+        set(INSTALL_GTEST OFF)
         FetchContent_Declare(googletest URL https://github.com/google/googletest/archive/refs/heads/main.zip)
         FetchContent_MakeAvailable(googletest)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ cmake_policy(SET CMP0135 NEW) # https://cmake.org/cmake/help/latest/policy/CMP01
 
 project(minja VERSION 1.0.0 LANGUAGES CXX)
 
+add_library(minja INTERFACE)
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Test if clang-tidy is available
@@ -36,6 +38,8 @@ else()
     set(MINJA_FUZZTEST_ENABLED_DEFAULT ON)
     set(MINJA_USE_VENV_DEFAULT ON)
 endif()
+option(MINJA_TEST_ENABLED           "minja: Build with test(python interpreter required)"   ON)
+option(MINJA_EXAMPLE_ENABLED        "minja: Build with example"                             ON)
 option(MINJA_FUZZTEST_ENABLED       "minja: fuzztests enabled"                              MINJA_FUZZTEST_ENABLED_DEFAULT)
 option(MINJA_FUZZTEST_FUZZING_MODE  "minja: run fuzztests (if enabled) in fuzzing mode"     OFF)
 option(MINJA_USE_VENV               "minja: use Python venv for build"                      MINJA_USE_VENV_DEFAULT)
@@ -53,15 +57,19 @@ include(FetchContent)
 # Fetch nlohmann/json
 FetchContent_Declare(json URL https://github.com/nlohmann/json/archive/refs/heads/develop.zip)
 FetchContent_MakeAvailable(json)
+target_link_libraries(minja INTERFACE nlohmann_json::nlohmann_json)
 
-if (MINJA_FUZZTEST_ENABLED)
-    # Fetch google/fuzztest (and indirectly, gtest)
-    FetchContent_Declare(fuzztest URL https://github.com/google/fuzztest/archive/refs/heads/main.zip)
-    FetchContent_MakeAvailable(fuzztest)
-else()
-    # Fetch gtest
-    FetchContent_Declare(googletest URL https://github.com/google/googletest/archive/refs/heads/main.zip)
-    FetchContent_MakeAvailable(googletest)
+if(MINJA_TEST_ENABLED)
+    if (MINJA_FUZZTEST_ENABLED)
+        # Fetch google/fuzztest (and indirectly, gtest)
+        FetchContent_Declare(fuzztest URL https://github.com/google/fuzztest/archive/refs/heads/main.zip)
+        FetchContent_MakeAvailable(fuzztest)
+        message(STATUS "${fuzztest_BINARY_DIR}: ${${fuzztest_BINARY_DIR}}")
+    else()
+        # Fetch gtest
+        FetchContent_Declare(googletest URL https://github.com/google/googletest/archive/refs/heads/main.zip)
+        FetchContent_MakeAvailable(googletest)
+    endif()
 endif()
 
 # Use ccache if installed
@@ -77,25 +85,27 @@ if (NOT XCODE AND NOT MSVC AND NOT CMAKE_BUILD_TYPE)
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
-set(Python_FIND_STRATEGY LOCATION CACHE STRING "Python find strategy" FORCE)
-find_package(Python COMPONENTS Interpreter REQUIRED)
-if(MINJA_USE_VENV)
-    # Create a python venv w/ the required dependencies
-    set(VENV_DIR "${CMAKE_BINARY_DIR}/venv")
-    if(WIN32)
-        set(VENV_PYTHON "${VENV_DIR}/Scripts/python.exe")
-    else()
-        set(VENV_PYTHON "${VENV_DIR}/bin/python")
+if(MINJA_TEST_ENABLED)
+    set(Python_FIND_STRATEGY LOCATION CACHE STRING "Python find strategy" FORCE)
+    find_package(Python COMPONENTS Interpreter REQUIRED)
+    if(MINJA_USE_VENV)
+        # Create a python venv w/ the required dependencies
+        set(VENV_DIR "${CMAKE_BINARY_DIR}/venv")
+        if(WIN32)
+            set(VENV_PYTHON "${VENV_DIR}/Scripts/python.exe")
+        else()
+            set(VENV_PYTHON "${VENV_DIR}/bin/python")
+        endif()
+        execute_process(
+            COMMAND ${Python_EXECUTABLE} -m venv "${VENV_DIR}"
+            COMMAND_ERROR_IS_FATAL ANY)
+        execute_process(
+            COMMAND ${VENV_PYTHON} -m pip install -r "${CMAKE_SOURCE_DIR}/requirements.txt"
+            COMMAND_ERROR_IS_FATAL ANY)
+        set(Python_EXECUTABLE "${VENV_PYTHON}" CACHE FILEPATH "Path to Python executable in venv" FORCE)
     endif()
-    execute_process(
-        COMMAND ${Python_EXECUTABLE} -m venv "${VENV_DIR}"
-        COMMAND_ERROR_IS_FATAL ANY)
-    execute_process(
-        COMMAND ${VENV_PYTHON} -m pip install -r "${CMAKE_SOURCE_DIR}/requirements.txt"
-        COMMAND_ERROR_IS_FATAL ANY)
-    set(Python_EXECUTABLE "${VENV_PYTHON}" CACHE FILEPATH "Path to Python executable in venv" FORCE)
+    message(STATUS "Python executable: ${Python_EXECUTABLE}")
 endif()
-message(STATUS "Python executable: ${Python_EXECUTABLE}")
 
 find_program(CPPCHECK cppcheck)
 if(CPPCHECK)
@@ -103,14 +113,29 @@ if(CPPCHECK)
   message(STATUS "cppcheck found: ${CPPCHECK}")
 endif()
 
-message(STATUS "${fuzztest_BINARY_DIR}: ${${fuzztest_BINARY_DIR}}")
-include_directories(
-    include/minja
-    ${json_SOURCE_DIR}/include
+include(GNUInstallDirs)
+target_include_directories(minja INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-add_subdirectory(examples)
+install(FILES
+  ${PROJECT_SOURCE_DIR}/include/minja/minja.hpp
+  ${PROJECT_SOURCE_DIR}/include/minja/chat-template.hpp
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/minja
+)
+install(
+  TARGETS minja
+  EXPORT "${TARGETS_EXPORT_NAME}"
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/minja  # for downstream projects
+)
 
-enable_testing()
-include(GoogleTest)
-add_subdirectory(tests)
+if(MINJA_EXAMPLE_ENABLED)
+    add_subdirectory(examples)
+endif()
+
+if(MINJA_TEST_ENABLED)
+    enable_testing()
+    include(GoogleTest)
+    add_subdirectory(tests)
+endif()

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ It is **not general purpose**: it includes just what’s needed for actual chat 
 
 This library is header-only: just copy the header(s) you need, make sure to use a compiler that handles C++17 and you're done. Oh, and get [nlohmann::json](https://github.com/nlohmann/json) in your include path.
 
+If your project is based on [cmake](https://cmake.org/), can simply import by using `FetchContent`.
+```
+FetchContent_Declare(minja GIT_REPOSITORY "https://github.com/google/minja")
+FetchContent_MakeAvailable(minja)
+
+target_link_libraries(<YOUR_TARGET> PRIVATE minja)
+```
+
 See API in [minja/minja.hpp](./include/minja/minja.hpp) and [minja/chat-template.hpp](./include/minja/chat-template.hpp) (experimental).
 
 For raw Jinja templating (see [examples/raw.cpp](./examples/raw.cpp)):

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -11,7 +11,7 @@ foreach(example
 )
     add_executable(${example} ${example}.cpp)
     target_compile_features(${example} PUBLIC cxx_std_17)
-    target_link_libraries(${example} PRIVATE nlohmann_json::nlohmann_json)
+    target_link_libraries(${example} PRIVATE minja)
     if (CMAKE_SYSTEM_NAME STREQUAL "Windows" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
         target_compile_definitions(${example} PUBLIC _CRT_SECURE_NO_WARNINGS)
     endif()

--- a/examples/chat-template.cpp
+++ b/examples/chat-template.cpp
@@ -6,7 +6,7 @@
     https://opensource.org/licenses/MIT.
 */
 // SPDX-License-Identifier: MIT
-#include <chat-template.hpp>
+#include <minja/chat-template.hpp>
 #include <iostream>
 
 using json = nlohmann::ordered_json;

--- a/examples/raw.cpp
+++ b/examples/raw.cpp
@@ -6,7 +6,7 @@
     https://opensource.org/licenses/MIT.
 */
 // SPDX-License-Identifier: MIT
-#include <minja.hpp>
+#include <minja/minja.hpp>
 #include <iostream>
 
 using json = nlohmann::ordered_json;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,7 +13,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "ar
     target_compile_options(gtest PRIVATE -Wno-language-extension-token)
 endif()
 target_link_libraries(test-syntax PRIVATE
-    nlohmann_json::nlohmann_json
+    minja
     gtest_main
     gmock
 )
@@ -28,7 +28,7 @@ else()
         target_compile_options(gtest PRIVATE -Wno-language-extension-token)
     endif()
     target_link_libraries(test-chat-template PRIVATE
-        nlohmann_json::nlohmann_json
+        minja
         gtest_main
         gmock
     )
@@ -41,7 +41,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "ar
     target_compile_options(gtest PRIVATE -Wno-language-extension-token)
 endif()
 target_link_libraries(test-polyfills PRIVATE
-    nlohmann_json::nlohmann_json
+    minja
     gtest_main
     gmock
 )
@@ -61,7 +61,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "ar
     target_compile_options(gtest PRIVATE -Wno-language-extension-token)
 endif()
 target_link_libraries(test-capabilities PRIVATE
-    nlohmann_json::nlohmann_json
+    minja
     gtest_main
     gmock
 )
@@ -77,7 +77,7 @@ target_compile_features(test-supported-template PUBLIC cxx_std_17)
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
     target_compile_definitions(test-supported-template PUBLIC _CRT_SECURE_NO_WARNINGS)
 endif()
-target_link_libraries(test-supported-template PRIVATE nlohmann_json::nlohmann_json)
+target_link_libraries(test-supported-template PRIVATE minja)
 
 # https://huggingface.co/models?other=conversational
 # https://huggingface.co/spaces/open-llm-leaderboard/open_llm_leaderboard#/?types=fine-tuned%2Cchat

--- a/tests/test-capabilities.cpp
+++ b/tests/test-capabilities.cpp
@@ -6,7 +6,7 @@
     https://opensource.org/licenses/MIT.
 */
 // SPDX-License-Identifier: MIT
-#include "chat-template.hpp"
+#include "minja/chat-template.hpp"
 
 #include <gtest/gtest.h>
 #include <gmock/gmock-matchers.h>

--- a/tests/test-chat-template.cpp
+++ b/tests/test-chat-template.cpp
@@ -7,7 +7,7 @@
     https://opensource.org/licenses/MIT.
 */
 // SPDX-License-Identifier: MIT
-#include "chat-template.hpp"
+#include "minja/chat-template.hpp"
 #include "gtest/gtest.h"
 #include <gtest/gtest.h>
 #include <gmock/gmock-matchers.h>

--- a/tests/test-fuzz.cpp
+++ b/tests/test-fuzz.cpp
@@ -9,8 +9,8 @@
 #include <fuzztest/fuzztest.h>
 #include <fuzztest/grammars/json_grammar.h>
 #include <gtest/gtest.h>
-#include <minja.hpp>
-#include <chat-template.hpp>
+#include <minja/minja.hpp>
+#include <minja/chat-template.hpp>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>

--- a/tests/test-polyfills.cpp
+++ b/tests/test-polyfills.cpp
@@ -6,14 +6,14 @@
     https://opensource.org/licenses/MIT.
 */
 // SPDX-License-Identifier: MIT
-#include "minja.hpp"
+#include "minja/minja.hpp"
 #include <gtest/gtest.h>
 #include <gmock/gmock-matchers.h>
 
 #include <fstream>
 #include <iostream>
 #include <string>
-#include "chat-template.hpp"
+#include "minja/chat-template.hpp"
 
 using namespace minja;
 

--- a/tests/test-supported-template.cpp
+++ b/tests/test-supported-template.cpp
@@ -6,7 +6,7 @@
     https://opensource.org/licenses/MIT.
 */
 // SPDX-License-Identifier: MIT
-#include "chat-template.hpp"
+#include "minja/chat-template.hpp"
 
 #include <string>
 #include <vector>

--- a/tests/test-syntax.cpp
+++ b/tests/test-syntax.cpp
@@ -6,7 +6,7 @@
     https://opensource.org/licenses/MIT.
 */
 // SPDX-License-Identifier: MIT
-#include "minja.hpp"
+#include "minja/minja.hpp"
 #include <gtest/gtest.h>
 #include <gmock/gmock-matchers.h>
 


### PR DESCRIPTION
Functionality of the minja library works well, and I think it's a great library. But it lacks proper CMake packaging, which makes it difficult to integrate smoothly within other CMake-based projects.

This PR introduces the following changes:

1. Install Command
The `install` command has been added so that running running `make install` will let you put the header files into `$CMAKE_INSTALL_PREFIX/include/minja`.

2. FetchContent Integration
A CMake target has been defined to support users who want to include minja using `FetchContent`. This means other C++ projects to can import minja like this:
```cmake
FetchContent_Declare(minja URL "minja-url")
FetchContent_MakeAvailable(minja)
```
3. Optional Python Dependency
Currently, minja's CMake configuration requires a Python interpreter. For users who only need the header files, two options have been added: MINJA_TEST_ENABLED and MINJA_EXAMPLE_ENABLED. By disabling these options, users can skip unnecessary CMake steps and avoid the Python dependency when it is not needed.
