### PR TITLE
Consider `"tool_calls"` instead of `"content"` in messages

### DIFF
--- a/include/minja/chat-template.hpp
+++ b/include/minja/chat-template.hpp
@@ -417,7 +417,6 @@ class chat_template {
                         }
                     }
                     if (polyfill_tool_calls) {
-                        auto content = message.at("content");
                         auto tool_calls = json::array();
                         for (const auto & tool_call : message.at("tool_calls")) {
                             if (tool_call.at("type") != "function") {
@@ -436,8 +435,11 @@ class chat_template {
                         auto obj = json {
                             {"tool_calls", tool_calls},
                         };
-                        if (!content.is_null() && !content.empty()) {
-                            obj["content"] = content;
+                        if (message.contains("content")) {
+                            auto content = message.at("content");
+                            if (!content.is_null() && !content.empty()) {
+                                obj["content"] = content;
+                            }
                         }
                         message["content"] = obj.dump(2);
                         message.erase("tool_calls");

--- a/include/minja/chat-template.hpp
+++ b/include/minja/chat-template.hpp
@@ -395,8 +395,8 @@ class chat_template {
 
             for (const auto & message_ : adjusted_messages) {
                 auto message = message_;
-                if (!message.contains("role") || !message.contains("content")) {
-                    throw std::runtime_error("message must have 'role' and 'content' fields: " + message.dump());
+                if (!message.contains("role") || (!message.contains("content") && !message.contains("tool_calls"))) {
+                    throw std::runtime_error("message must have 'role' and one of 'content' or 'tool_calls' fields: " + message.dump());
                 }
                 std::string role = message.at("role");
 


### PR DESCRIPTION
In the latest document of transformers([link](https://huggingface.co/docs/transformers/v4.51.3/en/chat_templating_writing#tool-calls)), a message containing 'tool calls' contains member with key `"tool_calls"` instead of "content".
```json
{
  "role": "assistant",
  "tool_calls": [
    {
      "type": "function",
      "function": {
        "name": "multiply",
        "arguments": {
          "a": 5,
          "b": 6
        }
      }
    }
  ]
}
```

The 'tool call' messages are not necessarily included as input messages because they are model outputs rather than model inputs. However, they are necessary to provide context during the process of providing tool execution results or after.

Currently, a message without `"content"` cannot be put into `chat_template::apply()` due to the validation logic as follows.
https://github.com/google/minja/blob/fcb5a0d3380fd1147c15be332b185a81e7aeae65/include/minja/chat-template.hpp#L398-L399

When referencing other lines of code, it seems like it's required to include a member with a `"content"` key, even if it's null or an empty string. However, I don't think it's very persuasive to require even an empty `"content"` when `"tool_calls"` can replace it. So I propose to require only one of `"content"` and `"tool_calls"`, as in this PR.