### PR TITLE
Add `true` and `false` as operands of `is` and `is not`

### DIFF
--- a/include/minja/minja.hpp
+++ b/include/minja/minja.hpp
@@ -1306,6 +1306,8 @@ public:
               if (name == "iterable") return l.is_iterable();
               if (name == "sequence") return l.is_array();
               if (name == "defined") return !l.is_null();
+              if (name == "true") return l.to_bool();
+              if (name == "false") return !l.to_bool();
               throw std::runtime_error("Unknown type for 'is' operator: " + name);
             };
             auto value = eval();

--- a/tests/test-syntax.cpp
+++ b/tests/test-syntax.cpp
@@ -218,6 +218,18 @@ TEST(SyntaxTest, SimpleCases) {
         "False",
         render(R"({% set foo = true %}{{ not foo is defined }})", {}, {}));
     EXPECT_EQ(
+        "True",
+        render(R"({% set foo = true %}{{ foo is true }})", {}, {}));
+    EXPECT_EQ(
+        "False",
+        render(R"({% set foo = true %}{{ foo is false }})", {}, {}));
+    EXPECT_EQ(
+        "True",
+        render(R"({% set foo = false %}{{ foo is not true }})", {}, {}));
+    EXPECT_EQ(
+        "False",
+        render(R"({% set foo = false %}{{ foo is not false }})", {}, {}));
+    EXPECT_EQ(
         R"({"a": "b"})",
         render(R"({{ {"a": "b"} | tojson }})", {}, {}));
     EXPECT_EQ(


### PR DESCRIPTION
As mentioned in #64, some operators in [Qwen3's template](https://huggingface.co/Qwen/Qwen3-4B/blob/main/tokenizer_config.json#L230) are not supported yet on latest minja.

#66 fixes most of them, but I found another problem during my tests on Qwen3.
I wanted to disable 'thinking' at all in Qwen3, by passing over `inputs.extra_context = {{"enable_thinking", "false"}};`, then I got `Unknown type for 'is' operator: false`.

So I needed to add `"false"` as possible name of rhs of `is` operator. (`"true"` must be one too, so added it too.)
After I applied these changes and #66, I finally succeeded to run templating for Qwen3's in my case.

Tests for these changes are also added.