### PR TITLE
fix: use `""` instead of `nullptr` for templates requiring non null content

### DIFF
--- a/include/minja/chat-template.hpp
+++ b/include/minja/chat-template.hpp
@@ -162,10 +162,14 @@ class chat_template {
         }), false);
         caps_.supports_tools = contains(out, "some_tool");
 
+        auto out_empty = try_raw_render(json::array({dummy_user_msg, {{"role", "assistant"}, {"content", ""}}}), {}, false);
+        auto out_null = try_raw_render(json::array({dummy_user_msg, {{"role", "assistant"}, {"content", nullptr}}}), {}, false);
+        caps_.requires_non_null_content = contains(out_empty, user_needle) && !contains(out_null, user_needle);
+
         auto make_tool_calls_msg = [&](const json & tool_calls) {
             return json {
                 {"role", "assistant"},
-                {"content", nullptr},
+                {"content", caps_.requires_non_null_content? "" : nullptr},
                 {"tool_calls", tool_calls},
             };
         };
@@ -195,9 +199,6 @@ class chat_template {
 
         caps_.supports_tool_calls = tool_call_renders_str_arguments || tool_call_renders_obj_arguments;
         caps_.requires_object_arguments = !tool_call_renders_str_arguments && tool_call_renders_obj_arguments;
-        auto out_empty = try_raw_render(json::array({dummy_user_msg, {{"role", "assistant"}, {"content", ""}}}), {}, false);
-        auto out_null = try_raw_render(json::array({dummy_user_msg, {{"role", "assistant"}, {"content", nullptr}}}), {}, false);
-        caps_.requires_non_null_content = contains(out_empty, user_needle) && !contains(out_null, user_needle);
 
         if (caps_.supports_tool_calls) {
             auto dummy_args = caps_.requires_object_arguments ? dummy_args_obj : json(dummy_args_obj.dump());
@@ -234,7 +235,7 @@ class chat_template {
                 };
                 const json tool_call_msg {
                     {"role", "assistant"},
-                    {"content", nullptr},
+                    {"content", caps_.requires_non_null_content ? "" : nullptr},
                     {"tool_calls", json::array({
                         {
                             // TODO: detect if requires numerical id or fixed length == 6 like Nemo


### PR DESCRIPTION
## Description
Due to uses of `nullptr` to test templates which are `caps_.requires_non_null_content == true`, the capabilities of that template are being mis-estimated.
In the case I saw, even though the template covers 'tool call' and 'tool response', `caps_.supports_tool_calls` and `caps_.supports_tool_responses` were both `false`, so the tool calls and tool responses are rendered with the polyfills.

Currently in `main`, the non-null content requirement is being checked(`caps_.requires_non_null_content`), but it is difficult to find any meaningful use cases.
It seems desirable that this be used to suppress the above situation.