### PR TITLE
Fix null content for chat-template.

### DIFF
--- a/include/minja/chat-template.hpp
+++ b/include/minja/chat-template.hpp
@@ -165,11 +165,12 @@ class chat_template {
         auto out_empty = try_raw_render(json::array({dummy_user_msg, {{"role", "assistant"}, {"content", ""}}}), {}, false);
         auto out_null = try_raw_render(json::array({dummy_user_msg, {{"role", "assistant"}, {"content", nullptr}}}), {}, false);
         caps_.requires_non_null_content = contains(out_empty, user_needle) && !contains(out_null, user_needle);
-
+        
+        json j_null;
         auto make_tool_calls_msg = [&](const json & tool_calls) {
             return json {
                 {"role", "assistant"},
-                {"content", caps_.requires_non_null_content? "" : nullptr},
+                {"content", caps_.requires_non_null_content? "" : j_null},
                 {"tool_calls", tool_calls},
             };
         };
@@ -235,7 +236,7 @@ class chat_template {
                 };
                 const json tool_call_msg {
                     {"role", "assistant"},
-                    {"content", caps_.requires_non_null_content ? "" : nullptr},
+                    {"content", caps_.requires_non_null_content ? "" : j_null},
                     {"tool_calls", json::array({
                         {
                             // TODO: detect if requires numerical id or fixed length == 6 like Nemo


### PR DESCRIPTION
The `nullptr` cause `Test failed: basic_string: construction from null is not valid`.

The root cause is the ternary operator of `std::string` and `nullptr`

> Before C++23:
> Constructing a std::string from a null pointer (like nullptr or NULL) results in Undefined Behavior. This means the program's behavior is unpredictable and can lead to crashes or incorrect results.
> In C++23 and later:
> Constructing a std::string from a null pointer is explicitly disabled and will result in a compilation error. This prevents the undefined behavior from occurring.

https://softwareengineering.stackexchange.com/questions/450335/is-it-bad-practice-to-use-nullptr-in-ternary-operation

Change to use empty `json` `j_null` instead.
https://json.nlohmann.me/api/basic_json/is_null/

Tests pass with `./scripts/tests.sh`