### PR TITLE
Support `llava-hf/llava-1.5-7b-hf` with `.upper()` string method

### DIFF
--- a/include/minja/minja.hpp
+++ b/include/minja/minja.hpp
@@ -1541,6 +1541,16 @@ public:
           } else if (method->get_name() == "capitalize") {
             vargs.expectArgs("capitalize method", {0, 0}, {0, 0});
             return Value(capitalize(str));
+          } else if (method->get_name() == "upper") {
+            vargs.expectArgs("upper method", {0, 0}, {0, 0});
+            auto result = str;
+            std::transform(result.begin(), result.end(), result.begin(), ::toupper);
+            return Value(result);
+          } else if (method->get_name() == "lower") {
+            vargs.expectArgs("lower method", {0, 0}, {0, 0});
+            auto result = str;
+            std::transform(result.begin(), result.end(), result.begin(), ::tolower);
+            return Value(result);
           } else if (method->get_name() == "endswith") {
             vargs.expectArgs("endswith method", {1, 1}, {0, 0});
             auto suffix = vargs.args[0].get<std::string>();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -168,6 +168,7 @@ set(MODEL_IDS
     knifeayumu/Cydonia-v1.3-Magnum-v4-22B
     langgptai/qwen1.5-7b-chat-sa-v0.1
     LatitudeGames/Wayfarer-12B
+    llava-hf/llava-1.5-7b-hf
     LGAI-EXAONE/EXAONE-3.5-2.4B-Instruct
     LGAI-EXAONE/EXAONE-3.5-7.8B-Instruct
     lightblue/DeepSeek-R1-Distill-Qwen-7B-Japanese

--- a/tests/test-syntax.cpp
+++ b/tests/test-syntax.cpp
@@ -91,6 +91,14 @@ TEST(SyntaxTest, SimpleCases) {
     EXPECT_EQ("abcXYZabcXYZabc",
         render("{{ 'abcXYZabcXYZabc'.replace('def', 'ok') }}", {}, {}));
 
+    EXPECT_EQ("HELLO WORLD", render("{{ 'hello world'.upper() }}", {}, {}));
+    EXPECT_EQ("MIXED", render("{{ 'MiXeD'.upper() }}", {}, {}));
+    EXPECT_EQ("", render("{{ ''.upper() }}", {}, {}));
+    
+    EXPECT_EQ("hello world", render("{{ 'HELLO WORLD'.lower() }}", {}, {}));
+    EXPECT_EQ("mixed", render("{{ 'MiXeD'.lower() }}", {}, {}));
+    EXPECT_EQ("", render("{{ ''.lower() }}", {}, {}));
+
     EXPECT_EQ(
         "ok",
         render("{# Hey\nHo #}{#- Multiline...\nComments! -#}{{ 'ok' }}{# yo #}", {}, {}));


### PR DESCRIPTION
minja has `| upper` filter implementation, however some models use `.upper()` string methods in their chat templates, e.g. `llava-hf/llava-1.5-7b-hf`.

This PR:
- implements `.upper()` and `.lower()` string methods
- adds `llava-hf/llava-1.5-7b-hf` template