### PR TITLE
fix Qwen/QwQ-32B

### DIFF
--- a/include/minja/chat-template.hpp
+++ b/include/minja/chat-template.hpp
@@ -162,8 +162,15 @@ class chat_template {
         }), false);
         caps_.supports_tools = contains(out, "some_tool");
 
-        auto out_empty = try_raw_render(json::array({dummy_user_msg, {{"role", "assistant"}, {"content", ""}}}), {}, false);
-        auto out_null = try_raw_render(json::array({dummy_user_msg, {{"role", "assistant"}, {"content", nullptr}}}), {}, false);
+        const auto render_with_content = [&](const json & content) {
+            const json assistant_msg {{"role", "assistant"}, {"content", content}};
+            // Render two assistant messages as some templates like QwQ-32B are handling
+            // the content differently depending on whether it's the last message or not
+            // (to remove the <think> tag in all but the last message).
+            return try_raw_render(json::array({dummy_user_msg, assistant_msg, dummy_user_msg, assistant_msg}), {}, false);
+        };
+        auto out_empty = render_with_content("");
+        auto out_null = render_with_content(json());
         caps_.requires_non_null_content = contains(out_empty, user_needle) && !contains(out_null, user_needle);
         
         json j_null;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -320,9 +320,9 @@ set(MODEL_IDS
     xwen-team/Xwen-72B-Chat
     xwen-team/Xwen-7B-Chat
     Qwen/Qwen3-4B
+    Qwen/QwQ-32B
 
     # Broken, TODO:
-    # Qwen/QwQ-32B
     # ai21labs/AI21-Jamba-1.5-Large        # https://github.com/google/minja/issues/8
     # Almawave/Velvet-14B
     # deepseek-ai/DeepSeek-R1

--- a/tests/test-capabilities.cpp
+++ b/tests/test-capabilities.cpp
@@ -80,7 +80,7 @@ TEST(CapabilitiesTest, QwQ32B) {
     EXPECT_TRUE(caps.supports_system_role);
     EXPECT_TRUE(caps.supports_tools);
     EXPECT_TRUE(caps.supports_tool_calls);
-    EXPECT_FALSE(caps.supports_tool_responses);
+    EXPECT_TRUE(caps.supports_tool_responses);
     EXPECT_TRUE(caps.supports_parallel_tool_calls);
     EXPECT_TRUE(caps.requires_object_arguments);
     // EXPECT_TRUE(caps.requires_non_null_content);


### PR DESCRIPTION
Problems in that template came from the detection of whether content needs to be non-null, which needs to add more messages when the logic only triggers in some loop iterations.

```c++
  {%- for message in messages %}
    {%- if (message.role == "user") or (message.role == "system" and not loop.first) %}
        {{- '<|im_start|>' + message.role + '\n' + message.content + '<|im_end|>' + '\n' }}
    {%- elif message.role == "assistant" and not message.tool_calls %}
        {%- set content = message.content %}
        {%- if not loop.last %}
            {%- set content = message.content.split('</think>')[-1].lstrip('\n') %}
        {%- endif %}
        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
    {%- elif message.role == "assistant" %}
        {%- set content = message.content %}
        {%- if not loop.last %}
            {%- set content = message.content.split('</think>')[-1].lstrip('\n') %}
        {%- endif %}
        {{- '<|im_start|>' + message.role }}
```