### PR TITLE
feat(tojson): accept ensure_ascii kwarg for Jinja compatibility

### DIFF
--- a/tests/test-syntax.cpp
+++ b/tests/test-syntax.cpp
@@ -80,6 +80,8 @@ TEST(SyntaxTest, SimpleCases) {
     EXPECT_EQ("bcXYZab", render("{{ 'abcXYZabc'.strip('ac') }}", {}, {}));
 
     EXPECT_EQ(R"(["a", "b"])", render("{{ 'a b'.split(' ') | tojson }}", {}, {}));
+    // Accept ensure_ascii kwarg for compatibility, ignored by implementation
+    EXPECT_EQ(R"("test")", render(R"({{ 'test' | tojson(ensure_ascii=False) }})", {}, {}));
 
     EXPECT_EQ(
         "Ok",


### PR DESCRIPTION
## Summary
Accept  as an optional kwarg for the built-in  filter, matching Jinja usage like . The flag is accepted and ignored (nlohmann::json dumps UTF-8 by default), preventing an "Unknown argument ensure_ascii" error.

## Changes
- Extend  signature to include  (optional), preserve existing  behavior.
- Add a unit test verifying  renders without error.

## Rationale
Some templates (e.g., in LLM contexts) call . Previously, this caused a runtime error. This change improves compatibility without altering output semantics.

Fixes #82
